### PR TITLE
4.0.0-alpha.5 - Fix Config Comments (from defaults)

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,5 +1,5 @@
 @Suppress("PropertyName")
-var VERSION = "4.0.0-alpha.4"
+var VERSION = "4.0.0-alpha.5"
 
 plugins { // needed for the allprojects section to work
     id("java")

--- a/spigot-utils/src/main/java/com/kamikazejam/kamicommon/KamiPlugin.java
+++ b/spigot-utils/src/main/java/com/kamikazejam/kamicommon/KamiPlugin.java
@@ -18,6 +18,7 @@ import com.kamikazejam.kamicommon.util.log.LoggerService;
 import com.kamikazejam.kamicommon.util.log.PluginLogger;
 import lombok.Getter;
 import org.bukkit.Bukkit;
+import org.bukkit.event.HandlerList;
 import org.bukkit.event.Listener;
 import org.bukkit.plugin.java.JavaPlugin;
 import org.bukkit.scheduler.BukkitTask;
@@ -216,7 +217,6 @@ public abstract class KamiPlugin extends JavaPlugin implements Listener, Named, 
         for (Listener listener : listeners) {
             if (listener == null) { continue; }
             if (listenerList.contains(listener)) { continue; }
-            this.registerListeners(listener);
             listenerList.add(listener);
             count++;
         }
@@ -234,7 +234,7 @@ public abstract class KamiPlugin extends JavaPlugin implements Listener, Named, 
         for (Listener listener : listeners) {
             if (listener == null) { continue; }
             if (listenerList.remove(listener)) {
-                this.unregisterListeners(listener);
+                HandlerList.unregisterAll(listener);
                 count++;
             }
         }
@@ -266,7 +266,6 @@ public abstract class KamiPlugin extends JavaPlugin implements Listener, Named, 
         for (Disableable disableable : disableables) {
             if (disableable == null) { continue; }
             if (disableableList.contains(disableable)) { continue; }
-            this.registerDisableables(disableable);
             disableableList.add(disableable);
             count++;
         }
@@ -284,7 +283,6 @@ public abstract class KamiPlugin extends JavaPlugin implements Listener, Named, 
         for (Disableable disableable : disableables) {
             if (disableable == null) { continue; }
             if (disableableList.remove(disableable)) {
-                this.unregisterDisableables(disableable);
                 count++;
             }
         }
@@ -317,7 +315,6 @@ public abstract class KamiPlugin extends JavaPlugin implements Listener, Named, 
         for (BukkitTask task : tasks) {
             if (task == null) { continue; }
             if (taskList.contains(task)) { continue; }
-            this.registerTasks(task);
             taskList.add(task);
             count++;
         }
@@ -335,7 +332,7 @@ public abstract class KamiPlugin extends JavaPlugin implements Listener, Named, 
         for (BukkitTask task : tasks) {
             if (task == null) { continue; }
             if (taskList.remove(task)) {
-                this.unregisterTasks(task);
+                Bukkit.getScheduler().cancelTask(task.getTaskId());
                 count++;
             }
         }
@@ -547,4 +544,10 @@ public abstract class KamiPlugin extends JavaPlugin implements Listener, Named, 
     public final boolean registerConfigObserver(@NotNull ConfigObserver observer, @NotNull KamiConfig config) {
         return config.registerObserver(observer);
     }
+
+    /**
+     * Optional Override (with listening behavior)
+     */
+    @Override
+    public void onConfigLoaded(@NotNull KamiConfig config) { }
 }

--- a/spigot-utils/src/main/java/com/kamikazejam/kamicommon/configuration/spigot/ConfigObserver.java
+++ b/spigot-utils/src/main/java/com/kamikazejam/kamicommon/configuration/spigot/ConfigObserver.java
@@ -2,6 +2,12 @@ package com.kamikazejam.kamicommon.configuration.spigot;
 
 import org.jetbrains.annotations.NotNull;
 
+/**
+ * Interface for classes that want to be notified when a config is reloaded.<br>
+ * This interface requires one method to be fulfilled, and then after registering the observer, the method will be called when the config is reloaded.<br>
+ * The interface method is also called immediately on registration with the config.<br>
+ * See {@link KamiConfig#registerObserver(ConfigObserver)} for more information.
+ */
 public interface ConfigObserver {
-    default void onConfigLoaded(@NotNull KamiConfig config) {}
+    void onConfigLoaded(@NotNull KamiConfig config);
 }

--- a/spigot-utils/src/main/java/com/kamikazejam/kamicommon/configuration/spigot/KamiConfig.java
+++ b/spigot-utils/src/main/java/com/kamikazejam/kamicommon/configuration/spigot/KamiConfig.java
@@ -28,7 +28,7 @@ import java.util.function.Supplier;
  * This is an extension of a YamlConfiguration, so all get, set, and put methods are available. <br>
  * <br>
  * When extending this class, provide the File to the config in the super, and then add all desired comments <br>
- * Then you can use this object just like a YamlConfiguration, it has all the same methods plus {@link KamiConfig#save()} and {@link KamiConfig#reload()} <br>
+ * Then you can use this object just like a YamlConfiguration, it has all the same methods plus a few others like {@link KamiConfig#reload()} <br>
  */
 @SuppressWarnings({"unused", "UnusedReturnValue"})
 public class KamiConfig extends AbstractConfig<YamlConfiguration> implements ConfigurationSection {
@@ -66,7 +66,7 @@ public class KamiConfig extends AbstractConfig<YamlConfiguration> implements Con
 
         this.yamlHandler = new YamlHandler(this, plugin, file);
         this.config = yamlHandler.loadConfig(addDefaults, defaultSupplier);
-        save();
+        save(true); // Force save since there won't be any changes from load, but we want to write any new comments to file
     }
 
     @Override

--- a/spigot-utils/src/main/java/com/kamikazejam/kamicommon/yaml/spigot/YamlConfiguration.java
+++ b/spigot-utils/src/main/java/com/kamikazejam/kamicommon/yaml/spigot/YamlConfiguration.java
@@ -21,4 +21,14 @@ public class YamlConfiguration extends MemorySection implements AbstractYamlConf
     public boolean save() {
         return super.save(configFile);
     }
+
+    /**
+     * Saves the config to the file
+     * @param force If the config should be saved even if no changes were made
+     * @return IFF the config was saved (can be skipped if no changes were made & force is false)
+     */
+    @Override
+    public boolean save(boolean force) {
+        return super.save(configFile, force);
+    }
 }

--- a/standalone-utils/src/main/java/com/kamikazejam/kamicommon/configuration/standalone/AbstractConfig.java
+++ b/standalone-utils/src/main/java/com/kamikazejam/kamicommon/configuration/standalone/AbstractConfig.java
@@ -48,4 +48,12 @@ public abstract class AbstractConfig<T extends AbstractYamlConfiguration> {
         return getYamlConfiguration().save();
     }
 
+    /**
+     * Saves the config to the file
+     * @param force If the config should be saved even if no changes were made
+     * @return IFF the config was saved (can be skipped if no changes were made & force is false)
+     */
+    public boolean save(boolean force) {
+        return getYamlConfiguration().save(force);
+    }
 }

--- a/standalone-utils/src/main/java/com/kamikazejam/kamicommon/yaml/AbstractYamlConfiguration.java
+++ b/standalone-utils/src/main/java/com/kamikazejam/kamicommon/yaml/AbstractYamlConfiguration.java
@@ -8,6 +8,7 @@ import java.util.Set;
 
 public interface AbstractYamlConfiguration {
     boolean save();
+    boolean save(boolean force);
     boolean contains(String key);
     Set<String> getKeys(boolean deep);
     NodeTuple getNodeTuple(String key);

--- a/standalone-utils/src/main/java/com/kamikazejam/kamicommon/yaml/base/MemorySectionMethods.java
+++ b/standalone-utils/src/main/java/com/kamikazejam/kamicommon/yaml/base/MemorySectionMethods.java
@@ -473,7 +473,16 @@ public abstract class MemorySectionMethods<T extends AbstractMemorySection<?>> e
      * @return true IFF the config was saved successfully (can be skipped if the config is not changed)
      */
     public boolean save(File f) {
-        if (!isChanged()) { return false; }
+        return save(f, false);
+    }
+
+    /**
+     * Saves the config to the file
+     * @param force If the config should be saved even if no changes were made
+     * @return true IFF the config was saved successfully (can be skipped if the config is not changed & force is false)
+     */
+    public boolean save(File f, boolean force) {
+        if (!force && !isChanged()) { return false; }
 
         try {
             // Dump the Node (should keep comments)

--- a/standalone-utils/src/main/java/com/kamikazejam/kamicommon/yaml/standalone/YamlConfigurationStandalone.java
+++ b/standalone-utils/src/main/java/com/kamikazejam/kamicommon/yaml/standalone/YamlConfigurationStandalone.java
@@ -21,4 +21,14 @@ public class YamlConfigurationStandalone extends MemorySectionStandalone impleme
     public boolean save() {
         return super.save(configFile);
     }
+
+    /**
+     * Saves the config to the file
+     * @param force If the config should be saved even if no changes were made
+     * @return IFF the config was saved (can be skipped if no changes were made & force is false)
+     */
+    @Override
+    public boolean save(boolean force) {
+        return super.save(configFile, force);
+    }
 }


### PR DESCRIPTION
- Fixed a few things from previous PRs, including a few recursions in KamiPlugin from lazy copying that came from Module
- Fixed the config comments issue (where default comments were not being saved to the server-side file)
  - The issue was related to an "optimization" where if no new keys needed to be added to the config, it wouldn't rewrite the file. This in turn meant that even though new comments were available, it skipped the whole process.
  - A code comment (and TODO item) was added into AbstractYamlHandler for future reference and review

Took 32 minutes