### PR TITLE
4.0.0-alpha.8

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,5 +1,5 @@
 @Suppress("PropertyName")
-var VERSION = "4.0.0-alpha.7"
+var VERSION = "4.0.0-alpha.8"
 
 plugins { // needed for the allprojects section to work
     id("java")

--- a/spigot-utils/src/main/java/com/kamikazejam/kamicommon/KamiPlugin.java
+++ b/spigot-utils/src/main/java/com/kamikazejam/kamicommon/KamiPlugin.java
@@ -149,15 +149,6 @@ public abstract class KamiPlugin extends JavaPlugin implements Listener, Named, 
         // Call Their Disable Method
         onDisableInner();
 
-        // Cleanup any commands that were forgotten about
-        // Loop through KamiCommand.getAllInstances() without causing a ConcurrentModificationException
-        for (KamiCommand command : new ArrayList<>(KamiCommand.getAllInstances())) {
-            command.unregisterCommand();
-        }
-        try {
-            KamiCommonCommandRegistration.updateRegistrations();
-        }catch (Throwable ignored) {}
-
         // Cleanup Listeners, Tasks, and Disableables
         unregisterListeners();
         unregisterTasks();

--- a/spigot-utils/src/main/java/com/kamikazejam/kamicommon/SpigotUtilsSource.java
+++ b/spigot-utils/src/main/java/com/kamikazejam/kamicommon/SpigotUtilsSource.java
@@ -1,5 +1,6 @@
 package com.kamikazejam.kamicommon;
 
+import com.kamikazejam.kamicommon.command.KamiCommand;
 import com.kamikazejam.kamicommon.command.KamiCommonCommandRegistration;
 import com.kamikazejam.kamicommon.command.impl.kc.KamiCommonCommand;
 import com.kamikazejam.kamicommon.configuration.spigot.KamiConfig;
@@ -21,6 +22,8 @@ import org.bukkit.event.HandlerList;
 import org.bukkit.scheduler.BukkitTask;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+
+import java.util.ArrayList;
 
 @SuppressWarnings({"unused", "UnusedReturnValue"})
 public class SpigotUtilsSource {
@@ -51,7 +54,7 @@ public class SpigotUtilsSource {
         enabled = true;
 
         // Setup Commands
-        new KamiCommonCommandRegistration(plugin);
+        KamiCommonCommandRegistration.get(plugin); // Will schedule the automatic command registration after server start
         // SetUp NMS Event Adapters
         plugin.registerListeners(PreSpawnSpawnerAdapter.getSpawnerAdapter());
         // Register Core Command
@@ -112,6 +115,15 @@ public class SpigotUtilsSource {
         MixinTeleport.get().setActive(null);
         MixinSenderPs.get().setActive(null);
         MixinWorld.get().setActive(null);
+
+        // Cleanup any commands that were forgotten about
+        // Loop through KamiCommand.getAllInstances() without causing a ConcurrentModificationException
+        for (KamiCommand command : new ArrayList<>(KamiCommand.getAllInstances())) {
+            command.unregisterCommand();
+        }
+        try {
+            KamiCommonCommandRegistration.updateRegistrations();
+        }catch (Throwable ignored) {}
 
         boolean prev = enabled;
         enabled = false;


### PR DESCRIPTION
- Group up all calls to KamiCommonCommandRegistration#updateRegistrations that occur before start-up into 1 call that runs 1 tick after boot.
- Calls to KamiCommonCommandRegistration#updateRegistrations after start up are executed immediately.

Took 20 minutes