### PR TITLE
4.0.0-alpha.9

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,5 +1,5 @@
 @Suppress("PropertyName")
-var VERSION = "4.0.0-alpha.8"
+var VERSION = "4.0.0-alpha.9"
 
 plugins { // needed for the allprojects section to work
     id("java")

--- a/spigot-utils/src/main/java/com/kamikazejam/kamicommon/configuration/spigot/CachedConfig.java
+++ b/spigot-utils/src/main/java/com/kamikazejam/kamicommon/configuration/spigot/CachedConfig.java
@@ -1,0 +1,82 @@
+package com.kamikazejam.kamicommon.configuration.spigot;
+
+import com.cryptomorin.xseries.XMaterial;
+import com.kamikazejam.kamicommon.modules.ModuleConfig;
+import com.kamikazejam.kamicommon.util.MessageBuilder;
+import lombok.Getter;
+import lombok.Setter;
+import org.bukkit.Bukkit;
+import org.jetbrains.annotations.ApiStatus;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.List;
+import java.util.Optional;
+
+@Getter @Setter
+@SuppressWarnings("unused")
+public abstract class CachedConfig<T extends KamiConfig> implements ConfigObserver {
+    protected boolean shutdownOnFailure = true;
+    private boolean loaded = false;
+
+    private final @NotNull T config;
+    public CachedConfig(@NotNull T config) {
+        this.config = config;
+        // Register this class as an observer of the config
+        //  so the onConfigLoaded method is called automatically
+        config.registerObserver(this);
+    }
+
+    /**
+     * Manual reload method. Call this to have {@link #onConfigLoaded(KamiConfig)} called again & your cache reloaded.<br>
+     * This {@link CachedConfig} class as a member of {@link ConfigObserver} is automatically registered to receive all config reloads.<br>
+     * As such, calling this method is optional and not required. Any call to the config passed in the constructor, will trigger {@link #loadConfig}
+     */
+    public final void reloadConfig() {
+        try {
+            this.onConfigLoaded(this.config);
+            this.loaded = true;
+        }catch (Throwable t) {
+            t.printStackTrace();
+            if (shutdownOnFailure) {
+                Bukkit.getLogger().severe("Failed to load config, shutting down server.");
+                Bukkit.getServer().shutdown();
+            }
+        }
+    }
+
+    @ApiStatus.Internal
+    @SuppressWarnings("unchecked")
+    public final void onConfigLoaded(@NotNull KamiConfig config) {
+        loadConfig((T) config);
+    }
+
+    protected abstract void loadConfig(@NotNull T config);
+
+    // ------------------------------------ //
+    // Helper Methods
+    // ------------------------------------ //
+
+    public void warn(@NotNull String message) {
+        Bukkit.getLogger().warning(message);
+    }
+
+    public final @NotNull List<XMaterial> loadMaterials(@NotNull ModuleConfig config, @NotNull String key) {
+        return config.getStringList(key).stream()
+                .map(XMaterial::matchXMaterial)
+                .filter(mat -> {
+                    boolean present = mat.isPresent();
+                    if (!present) { warn("Invalid material in '" + key + "': " + mat); }
+                    return present;
+                })
+                .map(Optional::get)
+                .toList();
+    }
+
+    /**
+     * Constructs a new {@link MessageBuilder} with the given key and this config.
+     */
+    @NotNull
+    public MessageBuilder msg(@NotNull String key) {
+        return new MessageBuilder(config, key);
+    }
+}

--- a/spigot-utils/src/main/java/com/kamikazejam/kamicommon/modules/config/CachedModuleConfig.java
+++ b/spigot-utils/src/main/java/com/kamikazejam/kamicommon/modules/config/CachedModuleConfig.java
@@ -1,0 +1,22 @@
+package com.kamikazejam.kamicommon.modules.config;
+
+import com.kamikazejam.kamicommon.configuration.spigot.CachedConfig;
+import com.kamikazejam.kamicommon.modules.Module;
+import com.kamikazejam.kamicommon.modules.ModuleConfig;
+import lombok.Getter;
+import org.jetbrains.annotations.NotNull;
+
+@Getter
+@SuppressWarnings("unused")
+public abstract class CachedModuleConfig<M extends Module> extends CachedConfig<ModuleConfig> {
+    private final @NotNull M module;
+    public CachedModuleConfig(@NotNull M module) {
+        super(module.getConfig());
+        this.module = module;
+    }
+
+    @Override
+    public final void warn(@NotNull String message) {
+        module.warn(message);
+    }
+}


### PR DESCRIPTION
- Added CachedConfig and CachedModuleConfig as a caching layer for configs. They inherit ConfigObserver so that their loadConfig methods can be automatically called when the configs are reloaded.
- Added CachedModuleConfig as the ModuleConfig equivalent of CachedConfig (for use in a module structure)

Took 20 minutes