### PR TITLE
V4 EOL and final GitHub Release

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,23 +1,22 @@
-# 🌅 V4 Branch: Transitioning to Legacy 🌅
+# 🕰️ V4 Branch: Historical Archive 🕰️
 
 ---
 
-### ⚠️ **Important: Nearing End of Life (EOL)** ⚠️
+### 🚧 **Status: End of Life (EOL)** 🚧
 
-This `release/v4` branch currently represents the **active maintenance line** for version 4.
+This `release/v4` branch now serves purely as a **historical and archival snapshot** of the project's version 4 codebase.
 
-**Development on the next major version (`v5`) has officially commenced!** 🚀
+With the official release of the first `v5` alpha, **active development and maintenance for `v4` have ceased**.  
+All new development efforts are focused on `v5`.
 
-Once the **first official release of `v5` is published**, this `release/v4` branch will transition to an **End of Life (EOL)** state. At that point, `v5` will become the *only actively supported version* of this project, and `v4` will primarily remain for historical reference. There is no ETA for the `v5` release.
+**⚠️ Please be advised: No support, bug fixes, or new features will be provided for this branch.**
 
-You are strongly encouraged to migrate to `v5` once it becomes available.
+For the most up-to-date and supported version, please refer to the `main` branch (which now reflects `v5`).
 
 ---
 
-**For active `v5` development, please see the `release/v5` branch.**
-**For the latest stable release, refer to the `main` branch (currently pointing to `v4`).**
-
-
+**For active `v5` development, please see the `release/v5` branch.**  
+**For the latest published release (including prereleases), see the [Releases page](https://github.com/Jake-Moore/KamiCommon/releases).**
 
 &nbsp;
 > <a href="https://github.com/Jake-Moore/KamiCommon/releases/latest"> <img alt="Latest Release" src="https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/Jake-Moore/5dfd7c9bb8b81ae5867c81e9a77ee821/raw/test.json" /></a>

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,5 +1,5 @@
 @Suppress("PropertyName")
-var VERSION = "4.0.0-beta.17"
+var VERSION = "4.0.0"
 
 plugins { // needed for the allprojects section to work
     id("java")


### PR DESCRIPTION
- Publish one official 4.0.0 version for historical archival.
  - v4 was previously only available in snapshots, this final build reflects the last updated state of the v4 branch.
- Update v4 readme now that v5 builds are available.